### PR TITLE
Fixes a few installation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ Create a link to the Reporting Centre:
 <a href="{{ path('vivait_reporting') }}">Reporting Centre</a>
 ```
 
+Ensure your user entity implements `Vivait\ReportingBundle\Model\ReportingUserInterface`:
+
+```php
+class User extends BaseUser implements ReportingUserInterface
+{
+  ...
+}
+```
+
+And let this bundle know what your User entity is:
+
+```yaml
+vivait_reporting:
+    user_class: Vivait\MyAppBundle\Entity\User
+```
+
 ## Usage
 
 The reporting framework allows you to create classes that interact with each other so that useful and meaningful reports can be build without the complexities of dealing with the SQL queries directly.
@@ -59,7 +75,7 @@ class MyReport extends ReportBuilder
         $this->em = $entityManager;
         $this->securityContext = $securityContext;
     }
-    
+
     public function getTitle()
     {
         return 'Lead Counts';

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,6 @@
   "require-dev": {
     "phpspec/phpspec": "~2.0"
   },
-  "suggest": {
-    "andreybolonin/chartjs-bundle": "To use charts, please install this bundle"
-  },
   "config": {
     "bin-dir": "bin"
   },

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,14 @@
     "doctrine/common": "~2.2",
     "doctrine/orm": "~2.2",
     "symfony/security": "~2.1",
-    "symfony/options-resolver": "~2.1"
+    "symfony/options-resolver": "~2.1",
+    "nnnick/chartjs": "1.0.1.*"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0"
+  },
+  "suggest": {
+    "andreybolonin/chartjs-bundle": "To use charts, please install this bundle"
   },
   "config": {
     "bin-dir": "bin"

--- a/src/Vivait/ReportingBundle/Controller/ReportingController.php
+++ b/src/Vivait/ReportingBundle/Controller/ReportingController.php
@@ -409,6 +409,6 @@ class ReportingController extends Controller
         $em->remove($report);
         $em->flush();
 
-        return $this->redirect($this->generateUrl('vivait_reporting_build',['id'=>$parent_id]));
+        return $this->redirect($this->generateUrl('vivait_reporting_build', ['report' => $parent_id]));
     }
 }

--- a/src/Vivait/ReportingBundle/Controller/ReportingController.php
+++ b/src/Vivait/ReportingBundle/Controller/ReportingController.php
@@ -311,13 +311,14 @@ class ReportingController extends Controller
 
             return $this->redirectBack($request);
         }
+        $user_class = $em->getClassMetadata('Vivait\ReportingBundle\Entity\Report')->getAssociationTargetClass('shared_users');
 
-        $users = $this->getDoctrine()->getRepository('VivaAuthBundle:User')->findAllinTenant($this->getUser()->getCurrentTenant());
+        $users = $this->getDoctrine()->getRepository($user_class)->findAll();
         $report->addSharedUser($this->getUser());
 
         $form = $this->createFormBuilder($report)
             ->add('name', 'text')
-            ->add('shared_users', 'entity', ['class' => 'Vivait\ReportingBundle\Model\ReportingUserInterface', 'attr' => ['size' => 30], 'label' => 'Share With', 'multiple' => true, 'choices' => $users])
+            ->add('shared_users', 'entity', ['class' => $user_class, 'attr' => ['size' => 30], 'label' => 'Share With', 'multiple' => true, 'choices' => $users])
             ->getForm();
 
         $form->handleRequest($request);

--- a/src/Vivait/ReportingBundle/DependencyInjection/Configuration.php
+++ b/src/Vivait/ReportingBundle/DependencyInjection/Configuration.php
@@ -18,6 +18,13 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('vivait_reporting');
+        $rootNode
+            ->children()
+                ->scalarNode('user_class')
+                ->isRequired()
+                ->end()
+            ->end();
         return $treeBuilder;
     }
 }

--- a/src/Vivait/ReportingBundle/DependencyInjection/VivaitReportingExtension.php
+++ b/src/Vivait/ReportingBundle/DependencyInjection/VivaitReportingExtension.php
@@ -25,11 +25,13 @@ class VivaitReportingExtension extends Extension implements PrependExtensionInte
         $configs = $container->getExtensionConfig($this->getAlias());
         $config = $this->processConfiguration(new Configuration(), $configs);
 
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
 
         $resolveEntitiesConfig = [
             'orm' => [
                 'resolve_target_entities' => [
-                    'Vivait\ReportingBundle\Model\ReportingUserInterface' => $config['user_class']
+                    $container->getParameter('vivait_reporting.reporting_user_interface.class') => $config['user_class']
                 ]
             ]
         ];
@@ -51,8 +53,7 @@ class VivaitReportingExtension extends Extension implements PrependExtensionInte
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('services.yml');
+
     }
 
 }

--- a/src/Vivait/ReportingBundle/DependencyInjection/VivaitReportingExtension.php
+++ b/src/Vivait/ReportingBundle/DependencyInjection/VivaitReportingExtension.php
@@ -28,21 +28,19 @@ class VivaitReportingExtension extends Extension implements PrependExtensionInte
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
 
-        $resolveEntitiesConfig = [
+        //Set user target entities
+        $this->prependConfig('doctrine', $container, [
             'orm' => [
                 'resolve_target_entities' => [
                     $container->getParameter('vivait_reporting.reporting_user_interface.class') => $config['user_class']
                 ]
             ]
-        ];
+        ]);
 
-        foreach ($container->getExtensions() as $name => $extension) {
-            switch ($name) {
-                case 'doctrine':
-                    $container->prependExtensionConfig($name, $resolveEntitiesConfig);
-                    break;
-            }
-        }
+        //Set Assetic bundles
+        $this->prependConfig('assetic', $container, [
+            'bundles' => ['VivaitReportingBundle']
+        ]);
     }
 
     /**
@@ -52,8 +50,22 @@ class VivaitReportingExtension extends Extension implements PrependExtensionInte
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
+    }
 
-
+    /**
+     * @param $configNode
+     * @param ContainerBuilder $container
+     * @param $config
+     */
+    private function prependConfig($configNode, ContainerBuilder $container, $config)
+    {
+        foreach ($container->getExtensions() as $name => $extension) {
+            switch ($name) {
+                case $configNode:
+                    $container->prependExtensionConfig($name, $config);
+                    break;
+            }
+        }
     }
 
 }

--- a/src/Vivait/ReportingBundle/Resources/config/services.yml
+++ b/src/Vivait/ReportingBundle/Resources/config/services.yml
@@ -1,3 +1,6 @@
+parameters:
+    vivait_reporting.reporting_user_interface.class: Vivait\ReportingBundle\Model\ReportingUserInterface
+
 services:
     vivait_reporting:
         class: Vivait\ReportingBundle\Services\ReportingService

--- a/src/Vivait/ReportingBundle/Resources/views/Default/report.html.twig
+++ b/src/Vivait/ReportingBundle/Resources/views/Default/report.html.twig
@@ -4,7 +4,7 @@
     {{ parent() }}
 
     {% javascripts
-    "bundles/andreyboloninchartjs/Chart.min.js" %}
+    "%kernel.root_dir%/../vendor/nnnick/chartjs/Chart.min.js" %}
     <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}
 {% endblock head_script %}


### PR DESCRIPTION
Fixes a few installation issues I had:

* Your application's User class must implement `ReportingUserInterface`, so I added a config option for the bundle to quickly set the `resolve_target_entities` option, instead of having to manually set it.
* Assetic `VivaitReportingBundle` bundle is automatically set in the bundle's extension
* No longer depends on `andreybolonin/chartjs-bundle`, uses direct js dependency instead on `nnnick/chartjs`